### PR TITLE
docs: add getting started section to README

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.x"
+          python-version: 3.11
       - uses: snok/install-poetry@v1
       - name: Install Dependencies
         run: poetry install

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # airthings-ble
 
-Library to control Airthings devices through BLE, primarily meant to be used in Home Assistant.
+Library to control Airthings devices through BLE, primarily meant to be used in
+the [Home Assistant integration](https://www.home-assistant.io/integrations/airthings_ble/).
+
+## Getting Started
+
+Prerequisites:
+
+- [Python 3.7.2+](https://www.python.org/downloads/)
+- [Poetry](https://python-poetry.org/docs/#installation)
+
+Install dependencies:
+
+```bash
+poetry install
+```
+
+Run tests:
+
+```bash
+poetry run pytest
+```
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the [Home Assistant integration](https://www.home-assistant.io/integrations/airt
 
 Prerequisites:
 
-- [Python 3.7.2+](https://www.python.org/downloads/)
+- [Python](https://www.python.org/downloads/) with version 3.11 that is required by Home Assistant ([docs](https://developers.home-assistant.io/docs/development_environment?_highlight=python&_highlight=versi#manual-environment))
 - [Poetry](https://python-poetry.org/docs/#installation)
 
 Install dependencies:


### PR DESCRIPTION
- Adding the section for better guidance on how to set up the project (it can be helpful to Python newbies)
- Bound Python version to 3.11 to respect [HA requirements](https://developers.home-assistant.io/docs/development_environment?_highlight=python&_highlight=versi#manual-environment)