### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,12 +11,16 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.11'
+
       - name: Install labels
         run: pip install labels
+
       - name: Sync config with Github
         run: labels -u ${{ github.repository_owner }} -t ${{ secrets.GITHUB_TOKEN }} sync -f .github/labels.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,14 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
-      - uses: snok/install-poetry@v1
+          python-version: '3.11'
+
+      - name: Setup Poetry
+        uses: snok/install-poetry@v1
+
       - name: Install Dependencies
         run: poetry install
+
       - name: Run linters
         run: poetry run make lint
+
       - name: Run tests
         run: poetry run pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,16 @@ jobs:
       contents: write
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: '3.11'
+
       - name: Update pyproject.toml Version
         run: |
           pip install tomlkit
@@ -42,6 +44,7 @@ jobs:
           with open('pyproject.toml', 'w') as file:
             file.write(tomlkit.dumps(content))
           "
+
       - name: Update __init__.py version
         run: | 
           version="${{ github.event.inputs.tag }}"
@@ -57,13 +60,16 @@ jobs:
           git push
           git tag ${{ github.event.inputs.tag }}
           git push --tags
+
       - name: Build source and wheel distributions
         run: |
           python -m pip install --upgrade build twine
           python -m build
           twine check --strict dist/*
+
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
We're getting this warning:

```
In scope of this release, we update node version runtime from node16 to node20 (https://github.com/actions/setup-python/pull/772). Besides, we update dependencies to the latest versions.
```

[checkout v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)
(latest version is `v4.1.1`, but we were using `3.x`)
> Update default runtime to node20 by @takost in https://github.com/actions/checkout/pull/1436

[setup-python v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)
> In scope of this release, we update node version runtime from node16 to node20 (https://github.com/actions/setup-python/pull/772). Besides, we update dependencies to the latest versions.